### PR TITLE
Bullet2

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -9,7 +9,8 @@ module  Admin
 
     def show
       order = Order.find(params[:id])
-      render :show, locals: { order: order, order_presenter: OrderPresenter.new(order) }
+      products = order.products.includes(%i[brand category])
+      render :show, locals: { order: order, products: products, order_presenter: OrderPresenter.new(order) }
     end
   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -3,7 +3,7 @@
 module  Admin
   class OrdersController < AdminController
     def index
-      @pagy, orders = pagy(Order.order(created_at: :desc))
+      @pagy, orders = pagy(Order.order(created_at: :desc).includes(:user))
       render :index, locals: { orders: orders }
     end
 

--- a/app/views/admin/orders/_order_products_table.html.erb
+++ b/app/views/admin/orders/_order_products_table.html.erb
@@ -8,7 +8,7 @@
     </tr>
   </thead>
   <tbody scope="col">
-    <% products.includes([:brand, :category]).each do |product| %>
+    <% products.each do |product| %>
       <tr scope="row">
         <td>
           <%= product.name %>

--- a/app/views/admin/orders/_order_products_table.html.erb
+++ b/app/views/admin/orders/_order_products_table.html.erb
@@ -8,7 +8,7 @@
     </tr>
   </thead>
   <tbody scope="col">
-    <% products.each do |product| %>
+    <% products.includes([:brand, :category]).each do |product| %>
       <tr scope="row">
         <td>
           <%= product.name %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -9,7 +9,7 @@
       </div>
     </div>
     <div class="row">
-      <%= render partial: 'admin/orders/order_products_table', locals: {products: order.products, order_presenter: order_presenter} %>
+      <%= render partial: 'admin/orders/order_products_table', locals: {products: products, order_presenter: order_presenter} %>
     </div>
   </div>
 </div>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -9,7 +9,7 @@
       </div>
     </div>
     <div class="row">
-      <%= render partial: 'admin/orders/order_products_table', locals: {products: products, order_presenter: order_presenter} %>
+      <%= render partial: 'admin/orders/order_products_table', locals: { products: products, order_presenter: order_presenter } %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Gem bullet pokazał mi kolejne n+1. Żeby uniknąć zapytań  do db w widoku(`includes`), postanowiłem przekazać `products` osobno z `orders` i bezpośrednio z kontrolera. Wiem, że to pewnie nie jest idealne podawać to osobno, ale jedyne alternatywy jakie widzę to
- zostawić to includes w widoku
- stworzyć funkcję w modelu
- stworzyć funkcję w prezenterze

A te dwa ostatnie to niepotrzebne śmiecenie, bo to zawołanie jest raczej specyficzne tylko dla tego widoku