### PR TITLE
bug fix create payment for all orders

### DIFF
--- a/db/migrate/20210731152239_create_payment.rb
+++ b/db/migrate/20210731152239_create_payment.rb
@@ -1,0 +1,9 @@
+class CreatePayment < ActiveRecord::Migration[6.1]
+  def up
+    Order.find_each(&:create_payment)
+  end
+
+  def down
+    Order.find_each { |order| order.payment.destroy }
+  end
+end

--- a/db/migrate/20210731152239_create_payment.rb
+++ b/db/migrate/20210731152239_create_payment.rb
@@ -1,9 +1,0 @@
-class CreatePayment < ActiveRecord::Migration[6.1]
-  def up
-    Order.find_each(&:create_payment)
-  end
-
-  def down
-    Order.find_each { |order| order.payment.destroy }
-  end
-end

--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 namespace :one_time do
-  desc 'create a shipment for allready existing orders'
+  desc 'create shipments for allready existing orders'
   task create_shipments: :environment do
     Order.find_each(&:create_shipment)
+  end
+
+  desc 'Create products for allready existing orders'
+  task create_products: :environment do
+    Order.find_each(&:create_payment)
   end
 end


### PR DESCRIPTION
If there were any orders created on production before the previous PR their payment would be nil. This PR introduces a ~~migration~~ rake task, creating a payment for all existing orders.